### PR TITLE
Fixed random forest error for large sample sizes

### DIFF
--- a/R/calculateRF.R
+++ b/R/calculateRF.R
@@ -27,11 +27,11 @@ calculateRF <- function(y, geno.mat){
     form <- formula("y ~ .")
 
     ## Run standard random forest function
-    rf_default <- randomForest(form, data = data.frame(y, geno.mat), importance = TRUE, proximity = TRUE)
+    rf_default <- randomForest(form, data = data.frame(y, geno.mat), importance = TRUE, proximity = FALSE)
     rf_default <- data.frame(rf_default$importance)
 
     ## Run default viRandomForest function
-    virf_default <- viRandomForests(form, data = data.frame(y, geno.mat), importance = TRUE, proximity=TRUE)
+    virf_default <- viRandomForests(form, data = data.frame(y, geno.mat), importance = TRUE, proximity = FALSE)
     virf_default <- data.frame(virf_default$importance)
 
     #####**********  Function to call IV using Tukey Mild criteria


### PR DESCRIPTION
The random forest method errored out when given a large sample sizes. Setting `proximity=FALSE` in both instances avoids the creation of an $n \times n$ matrix. This should fix the error. Output from the function with `TRUE` and `FALSE` for proximity was compared and is identical in the `exampleData` tutorial results.

Verification was performed with the code below. Note that for the random forest, to compare results, setting a seed is required to give identical results:
```r
library(RIFT)
library(randomForest)
library(viRandomForests)
library(data.table)

set.seed(123)
data(exampleData)
y <- exampleData$PHENOTYPE - 1
geno <- as.matrix(exampleData[,-c(1,2)])
results <- calculateRF(y, geno.mat = geno)
results$rf[results$rf$MeanDecreaseAccuracy.tukey,]
results$virf[results$virf$MeanDecreaseAccuracy.tukey,]

results.rf.old = read.table("rf.txt", header = TRUE, sep = "\t")
results.virf.old = read.table("virf.txt", header = TRUE, sep = "\t")

results.rf.old[results.rf.old$MeanDecreaseAccuracy.tukey,]
results.virf.old[results.virf.old$MeanDecreaseAccuracy.tukey,]

# Write rf and virf to two files
write.table(results$rf, file = "rf.txt", sep = "\t")
write.table(results$virf, file = "virf.txt", sep = "\t")
```